### PR TITLE
Cleanup warnings on Explore Screen

### DIFF
--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -1,24 +1,18 @@
 export const setFilter = async (array, filters) => {
   let filtered = [...array];
-  // filters.price != null && (filtered = sortArray(filtered, filters.price));
-  // filters.forSale &&
-  //   (filtered = filterBudz(
-  //     filtered,
-  //     (bud) => Boolean(bud.price) && bud.price > 0
-  //   ));
 
-  if (filters.id || filters.id == 0) {
-    let result = filtered.find((bud) => bud.id == filters.id);
+  if (filters.id || filters.id === 0) {
+    let result = filtered.find((bud) => bud.id === filters.id);
     filtered = result ? [result] : [];
   }
 
   if (filters.types.length > 0) {
     filtered = filtered.filter((bud) =>
-      filters.types.some((type) => type == bud.type)
+      filters.types.some((type) => type === bud.type)
     );
   }
   if (filters.gadgets.length > 0) {
-    if (filters.gadgets[0] == "No Gadget")
+    if (filters.gadgets[0] === "No Gadget")
       filtered = filtered.filter((bud) => bud.gadgets.length <= 0);
     else
       filtered = filtered.filter((bud) => {
@@ -34,7 +28,7 @@ export const setFilter = async (array, filters) => {
     );
   }
 
-  if (filters.gadgetsCount || filters.gadgetsCount == 0) {
+  if (filters.gadgetsCount || filters.gadgetsCount === 0) {
     filtered = filtered.filter(
       (bud) => bud.gadgets.length >= parseInt(filters.gadgetsCount)
     );
@@ -42,7 +36,7 @@ export const setFilter = async (array, filters) => {
 
   if (filters.order_id) {
     filtered = filtered.sort((a, b) =>
-      filters.order_id == "ASC" ? a.id - b.id : b.id - a.id
+      filters.order_id === "ASC" ? a.id - b.id : b.id - a.id
     );
   }
   if (filters.order_price) {
@@ -75,11 +69,11 @@ const sortArray = (array, price) => {
       return -1;
     }
     // otherwise, if we're ascending, lowest sorts first
-    else if (price == "ASC") {
+    else if (price === "ASC") {
       return a.price < b.price ? -1 : 1;
     }
     // if descending, highest sorts first
-    else if (price == "DESC") {
+    else if (price === "DESC") {
       return a.price < b.price ? 1 : -1;
     }
     // if (!a.price || !b.price) return 1;

--- a/src/components/Filter/FilterModal.jsx
+++ b/src/components/Filter/FilterModal.jsx
@@ -93,7 +93,6 @@ const FilterModal = ({ isOpen, onOpen, onClose }) => {
   const [sliderId, setSliderId] = React.useState([0, 9999]);
 
   React.useEffect(() => {
-    console.log(isOpen);
     if (!isOpen) return;
     const urlParams = new URLSearchParams(window.location.search);
     const typesArray = urlParams.getAll("type");
@@ -286,12 +285,12 @@ const FilterModal = ({ isOpen, onOpen, onClose }) => {
               <Box h={3} />
               <Slider
                 width="80%"
-                value={sliderGadgets == "Any" ? 0 : sliderGadgets}
+                value={sliderGadgets === "Any" ? 0 : sliderGadgets}
                 min={0}
                 max={12}
                 step={1}
                 onChange={(val) =>
-                  val == 0 ? setSliderGadgets("Any") : setSliderGadgets(val)
+                  val === 0 ? setSliderGadgets("Any") : setSliderGadgets(val)
                 }
               >
                 <SliderTrack>
@@ -398,7 +397,7 @@ const FilterModal = ({ isOpen, onOpen, onClose }) => {
                         onChange={(e) => {
                           const val = e.target.checked;
                           if (gadgets)
-                            if (gadget == "No Gadget") {
+                            if (gadget === "No Gadget") {
                               setGadgets(null);
                               setTimeout(() =>
                                 setGadgets({

--- a/src/templates/explore.js
+++ b/src/templates/explore.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Headroom from "react-headroom";
 import { Search, setFilter } from "../components/Filter";
 import InfiniteGrid from "../components/InfiniteGrid";
 import { FloatingButton } from "../components/Button";
@@ -35,17 +34,17 @@ const Explore = ({ pageContext: { spacebudz, initialOrder }, location }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const setColor = (order, up = true) => {
-    if (order == null) return "#b5b5b5";
-    if (order == "ASC" && up) return "black";
-    if (order == "ASC" && !up) return "#b5b5b5";
-    if (order == "DESC" && up) return "#b5b5b5";
-    if (order == "DESC" && !up) return "black";
+    if (order === null) return "#b5b5b5";
+    if (order === "ASC" && up) return "black";
+    if (order === "ASC" && !up) return "#b5b5b5";
+    if (order === "DESC" && up) return "#b5b5b5";
+    if (order === "DESC" && !up) return "black";
   };
 
   const numberOfAppliedFilter = () => {
     const f = filters;
     let count = 0;
-    if (f.id || f.id == 0) count += 1;
+    if (f.id || f.id === 0) count += 1;
     if (f.types) f.types.forEach(() => (count += 1));
     if (f.gadgets) f.gadgets.forEach(() => (count += 1));
     if (f.range && f.range.length > 0) count += 1;
@@ -73,12 +72,12 @@ const Explore = ({ pageContext: { spacebudz, initialOrder }, location }) => {
       order_price +
       on_sale
     ).toString();
-    if (searchString == recentSearch.current) return;
+    if (searchString === recentSearch.current) return;
     recentSearch.current = searchString;
     setLoading(true);
     if (
       id ||
-      id == 0 ||
+      id === 0 ||
       types.length > 0 ||
       gadgets.length > 0 ||
       range.length > 0 ||
@@ -87,7 +86,7 @@ const Explore = ({ pageContext: { spacebudz, initialOrder }, location }) => {
       order_price ||
       on_sale
     ) {
-      if (id || id == 0) setParam(id);
+      if (id || id === 0) setParam(id);
       await sleep();
       const f = filters;
       f.id = id;
@@ -97,7 +96,7 @@ const Explore = ({ pageContext: { spacebudz, initialOrder }, location }) => {
       f.gadgetsCount = gadgetsCount;
       f.order_id = order_id;
       f.order_price = order_price;
-      f.on_sale = on_sale;
+      f.on_sale = Boolean(on_sale);
       const filtered = await setFilter(fullList.current, f);
       setArray(null);
       setTimeout(() => setArray(filtered));
@@ -179,7 +178,7 @@ const Explore = ({ pageContext: { spacebudz, initialOrder }, location }) => {
                 onKeyUp={(e) => {
                   if (e.key === "Enter") {
                     window.scrollTo(0, 0);
-                    if (e.target.value == "") return;
+                    if (e.target.value === "") return;
                     window.history.pushState(
                       {},
                       null,
@@ -190,13 +189,13 @@ const Explore = ({ pageContext: { spacebudz, initialOrder }, location }) => {
                 onSearch={(e) => {
                   window.scrollTo(0, 0);
 
-                  if (e == "") return;
+                  if (e === "") return;
                   window.history.pushState({}, null, `/explore/?id=${e}`);
                 }}
                 onChange={(e) => {
                   if (e.target.value) e.persist();
                   if (
-                    e.target.value == "" &&
+                    e.target.value === "" &&
                     array.toString() != fullList.current
                   ) {
                     window.history.pushState({}, null, `/explore/`);
@@ -301,7 +300,7 @@ const Explore = ({ pageContext: { spacebudz, initialOrder }, location }) => {
                     onClick={() => {
                       const f = filters;
                       f.order_id = filters.order_id
-                        ? filters.order_id == "ASC"
+                        ? filters.order_id === "ASC"
                           ? "DESC"
                           : null
                         : "ASC";
@@ -345,7 +344,7 @@ const Explore = ({ pageContext: { spacebudz, initialOrder }, location }) => {
                     onClick={() => {
                       const f = filters;
                       f.order_price = filters.order_price
-                        ? filters.order_price == "ASC"
+                        ? filters.order_price === "ASC"
                           ? "DESC"
                           : null
                         : "ASC";

--- a/src/templates/spacebud.js
+++ b/src/templates/spacebud.js
@@ -1,7 +1,6 @@
 import { useDisclosure } from "@chakra-ui/hooks";
 import React from "react";
 import MiddleEllipsis from "react-middle-ellipsis";
-// import { Button } from "../components/Button";
 import { navigate } from "gatsby";
 import { useBreakpoint } from "gatsby-plugin-breakpoints";
 import Metadata from "../components/Metadata";
@@ -11,7 +10,6 @@ import {
   TradeModal,
   SuccessTransactionToast,
   PendingTransactionToast,
-  FailedTransactionToast,
   tradeErrorHandler,
 } from "../components/Modal";
 import { Share2 } from "@geist-ui/react-icons";
@@ -135,12 +133,13 @@ const SpaceBud = ({ pageContext: { spacebud } }) => {
     // check if twin
     if (Array.isArray(offerUtxo)) {
       if (
-        offerUtxo.length == 2 &&
-        (spacebud.id == 1903 || spacebud.id == 6413)
+        offerUtxo.length === 2 &&
+        (spacebud.id === 1903 || spacebud.id === 6413)
       ) {
         const ownerUtxo = offerUtxo.find(
-          (utxo) => utxo.tradeOwnerAddress.to_bech32() == connected
+          (utxo) => utxo.tradeOwnerAddress.to_bech32() === connected
         );
+
         if (ownerUtxo) {
           offerUtxo = ownerUtxo;
         } else {
@@ -179,11 +178,11 @@ const SpaceBud = ({ pageContext: { spacebud } }) => {
       details.bid.lovelace = bidUtxo.lovelace;
       details.bid.usd = (bidUtxo.lovelace / 10 ** 6) * fiatPrice * 10 ** 2;
     }
-    if (addresses.find((address) => address.address == connected))
+    if (addresses.find((address) => address.address === connected))
       details.offer.owner = true;
     if (offerUtxo) {
       addresses = addresses.map((address) =>
-        address.address == CONTRACT_ADDRESS
+        address.address === CONTRACT_ADDRESS
           ? { address: offerUtxo.tradeOwnerAddress.to_bech32() }
           : address
       );
@@ -200,7 +199,7 @@ const SpaceBud = ({ pageContext: { spacebud } }) => {
 
     //check if same address if there are 2
 
-    if (addresses.length > 1 && addresses[0].address == addresses[1].address) {
+    if (addresses.length > 1 && addresses[0].address === addresses[1].address) {
       addresses = [addresses[0]];
     }
 
@@ -280,7 +279,7 @@ const SpaceBud = ({ pageContext: { spacebud } }) => {
             }}
           >
             <div style={{ width: "100%", position: "relative" }}>
-              {(spacebud.id == 1903 || spacebud.id == 6413) && (
+              {(spacebud.id === 1903 || spacebud.id === 6413) && (
                 <img
                   src={spacebud.image}
                   style={{
@@ -309,7 +308,7 @@ const SpaceBud = ({ pageContext: { spacebud } }) => {
           </LinkName>
         </div>
         <Box h={6} />
-        {(spacebud.id == 1903 || spacebud.id == 6413) && (
+        {(spacebud.id === 1903 || spacebud.id === 6413) && (
           <>
             <div
               style={{


### PR DESCRIPTION
- Switch `==` for `===`
- Fix the following warning by making sure `on_sale` is always a `bool`.
```
Warning: Received the string `true` for the boolean attribute `checked`. Although this works, it will not work as expected if you pass the string "false". Did you mean checked={true}?
```