### PR TITLE
Linter warning  to prevent stall closure pitfalls

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,17 +1,17 @@
 import * as React from "react";
 
-export const useIsIntersecting = (ref, rootMargin) => {
+export const useIsIntersecting = (ref: { current: any }, rootMargin: any) => {
   const [isIntersecting, setIntersecting] = React.useState(false);
-  const observer = new IntersectionObserver(
-    ([entry]: any) => setIntersecting(entry.isIntersecting),
-    { rootMargin }
-  );
   React.useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]: any) => setIntersecting(entry.isIntersecting),
+      { rootMargin }
+    );
     observer.observe(ref.current);
     return () => {
       observer.disconnect();
     };
-  }, []);
+  }, [ref, rootMargin]);
   return isIntersecting;
 };
 


### PR DESCRIPTION
Line 5: The 'observer' object construction makes the dependencies of useEffect Hook (at line 14) change on every render. Move it inside the useEffect callback. Alternatively, wrap the initialization of 'observer' in its own useMemo() Hook.eslintreact-hooks/exhaustive-deps https://github.com/facebook/react/issues/14920

Line 15: React Hook React.useEffect has missing dependencies: 'ref' and 'rootMargin'. Either include them or remove the dependency array.eslintreact-hooks/exhaustive-deps